### PR TITLE
Bump jackson to 2.8.8 for Beam 2 upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
     <jline.version>${scala.version}</jline.version>
     <jline.groupid>org.scala-lang</jline.groupid>
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
-    <fasterxml.jackson.version>2.4.4</fasterxml.jackson.version>
+    <fasterxml.jackson.version>2.8.8</fasterxml.jackson.version>
     <snappy.version>1.1.2.1</snappy.version>
     <netlib.java.version>1.1.2</netlib.java.version>
     <calcite.version>1.2.0-incubating</calcite.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Bump fasterxml.jackson version to 2.8.8 to resolve jar conflict issue between Beam 2.0, 
I have test SimpleFileIO/Elasticsearch/Kafka/FilterRow/DataprepRun components with this spark-assembly, and all successful


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
