### PR TITLE
fix(TFD-4346): set security manager for python compnoent on livy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,6 +242,10 @@
         <enabled>false</enabled>
       </snapshots>
     </repository>
+    <repository>
+      <id>codice</id>
+      <url>http://artifacts.codice.org/content/repositories/releases/</url>
+    </repository>
   </repositories>
   <pluginRepositories>
     <pluginRepository>
@@ -271,6 +275,11 @@
       <groupId>org.spark-project.spark</groupId>
       <artifactId>unused</artifactId>
       <version>1.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codice.pro-grade</groupId>
+      <artifactId>pro-grade</artifactId>
+      <version>1.1.3</version>
     </dependency>
     <!--
          This is needed by the scalatest plugin, and so is declared here to be available in


### PR DESCRIPTION
## What changes were proposed in this pull request?
For python component security issue, we need to setup security manager on Livy side, when submit the job, so need pro-grade library available in spark folder for submit spark job

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
